### PR TITLE
fix: replace example credential literals in source manager descriptions

### DIFF
--- a/drdroid_debug_toolkit/core/integrations/source_managers/big_query_source_manager.py
+++ b/drdroid_debug_toolkit/core/integrations/source_managers/big_query_source_manager.py
@@ -54,7 +54,7 @@ class BigQuerySourceManager(SourceManager):
                     SourceKeyType.BIG_QUERY_SERVICE_ACCOUNT_JSON: FormField(
                         key_name=StringValue(value=get_connector_key_type_string(SourceKeyType.BIG_QUERY_SERVICE_ACCOUNT_JSON)),
                         display_name=StringValue(value="Service Account JSON"),
-                        description=StringValue(value='e.g. {\n  "type": "service_account",\n  "project_id": "my-project-123",\n  "private_key_id": "abc123...",\n  "private_key": "-----BEGIN PRIVATE KEY-----\\n..."\n}'),
+                        description=StringValue(value='e.g. {\n  "type": "<service-account-type>",\n  "project_id": "<your-project-id>",\n  "private_key_id": "<your-key-id>",\n  "private_key": "<your-private-key>"\n}'),
                         helper_text=StringValue(value="Paste the content of your Google Cloud Service Account JSON key file"),
                         data_type=LiteralType.STRING,
                         form_field_type=FormFieldType.MULTILINE_FT,

--- a/drdroid_debug_toolkit/core/integrations/source_managers/gcm_source_manager.py
+++ b/drdroid_debug_toolkit/core/integrations/source_managers/gcm_source_manager.py
@@ -228,7 +228,7 @@ class GcmSourceManager(SourceManager):
                     SourceKeyType.GCM_SERVICE_ACCOUNT_JSON: FormField(
                         key_name=StringValue(value=get_connector_key_type_string(SourceKeyType.GCM_SERVICE_ACCOUNT_JSON)),
                         display_name=StringValue(value="Service Account JSON"),
-                        description=StringValue(value='e.g. {"type": "service_account", "project_id": "my-project", "private_key_id": "abc123..."}'),
+                        description=StringValue(value='e.g. {"type": "<service-account-type>", "project_id": "<your-project-id>", "private_key_id": "<your-key-id>"}'),
                         helper_text=StringValue(value="Paste the entire JSON content of your service account key file from IAM & Admin > Service Accounts"),
                         data_type=LiteralType.STRING,
                         form_field_type=FormFieldType.MULTILINE_FT,

--- a/drdroid_debug_toolkit/core/integrations/source_managers/github_actions_source_manager.py
+++ b/drdroid_debug_toolkit/core/integrations/source_managers/github_actions_source_manager.py
@@ -55,7 +55,7 @@ class GithubActionsSourceManager(SourceManager):
                     SourceKeyType.GITHUB_ACTIONS_TOKEN: FormField(
                         key_name=StringValue(value=get_connector_key_type_string(SourceKeyType.GITHUB_ACTIONS_TOKEN)),
                         display_name=StringValue(value="GitHub Actions Token"),
-                        description=StringValue(value='e.g. "ghp_1234567890abcdefghijklmnopqrstuvwxyz"'),
+                        description=StringValue(value='e.g. "<your-github-personal-access-token>"'),
                         helper_text=StringValue(value="Enter your GitHub Personal Access Token with 'repo' and 'workflow' scopes from Developer Settings > Personal Access Tokens"),
                         data_type=LiteralType.STRING,
                         form_field_type=FormFieldType.TEXT_FT,

--- a/drdroid_debug_toolkit/core/integrations/source_managers/github_source_manager.py
+++ b/drdroid_debug_toolkit/core/integrations/source_managers/github_source_manager.py
@@ -223,7 +223,7 @@ class GithubSourceManager(SourceManager):
                     SourceKeyType.GITHUB_TOKEN: FormField(
                         key_name=StringValue(value=get_connector_key_type_string(SourceKeyType.GITHUB_TOKEN)),
                         display_name=StringValue(value="GitHub Token"),
-                        description=StringValue(value='e.g. "ghp_1234567890abcdefghijklmnopqrstuvwxyz"'),
+                        description=StringValue(value='e.g. "<your-github-personal-access-token>"'),
                         helper_text=StringValue(value="Enter your GitHub Personal Access Token with 'repo' and 'org:read' scopes from Developer Settings > Personal Access Tokens"),
                         data_type=LiteralType.STRING,
                         form_field_type=FormFieldType.TEXT_FT,

--- a/drdroid_debug_toolkit/core/integrations/source_managers/gke_source_manager.py
+++ b/drdroid_debug_toolkit/core/integrations/source_managers/gke_source_manager.py
@@ -65,7 +65,7 @@ class GkeSourceManager(SourceManager):
                     SourceKeyType.GKE_SERVICE_ACCOUNT_JSON: FormField(
                         key_name=StringValue(value=get_connector_key_type_string(SourceKeyType.GKE_SERVICE_ACCOUNT_JSON)),
                         display_name=StringValue(value="Service Account JSON"),
-                        description=StringValue(value='e.g. {"type": "service_account", "project_id": "my-project", "private_key_id": "abc123..."}'),
+                        description=StringValue(value='e.g. {"type": "<service-account-type>", "project_id": "<your-project-id>", "private_key_id": "<your-key-id>"}'),
                         helper_text=StringValue(value="Paste the entire JSON content of your service account key file from IAM & Admin > Service Accounts (requires Kubernetes Engine Admin role)"),
                         data_type=LiteralType.STRING,
                         form_field_type=FormFieldType.MULTILINE_FT,


### PR DESCRIPTION
The form-field `description` strings used `e.g. ghp_1234...` and `e.g. {"type":"service_account","private_key_id":"abc123..."}` placeholders that tripped secret-scanner regexes (Trivy / JFrog Xray) even though they are documentation examples, not credentials. Replace with `<your-*>` placeholders that display the same intent without matching detector patterns.

Files updated:
- big_query_source_manager.py
- gcm_source_manager.py
- gke_source_manager.py
- github_source_manager.py
- github_actions_source_manager.py